### PR TITLE
refactor: lint apps/components/shared files

### DIFF
--- a/apps/dokploy/components/shared/ChatwootWidget.tsx
+++ b/apps/dokploy/components/shared/ChatwootWidget.tsx
@@ -10,7 +10,7 @@ interface ChatwootWidgetProps {
 		launcherTitle?: string;
 		darkMode?: boolean;
 		hideMessageBubble?: boolean;
-		placement?: "right" | "left";
+		placement?: "left" | "right";
 		showPopoutButton?: boolean;
 		widgetStyle?: "standard" | "bubble";
 	};
@@ -41,7 +41,7 @@ export const ChatwootWidget = ({
 			position: "right",
 		};
 
-		(window as any).chatwootSDKReady = () => {
+		window.chatwootSDKReady = () => {
 			window.chatwootSDK?.run({ websiteToken, baseUrl });
 
 			const trySetUser = () => {
@@ -63,7 +63,7 @@ export const ChatwootWidget = ({
 		<Script
 			src={`${baseUrl}/packs/js/sdk.js`}
 			strategy="lazyOnload"
-			onLoad={() => (window as any).chatwootSDKReady?.()}
+			onLoad={() => window.chatwootSDKReady?.()}
 		/>
 	);
 };

--- a/apps/dokploy/components/shared/alert-block.tsx
+++ b/apps/dokploy/components/shared/alert-block.tsx
@@ -1,10 +1,10 @@
+import { AlertCircle, AlertTriangle, CheckCircle2, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
 interface Props extends React.ComponentPropsWithoutRef<"div"> {
 	icon?: React.ReactNode;
 	type?: "info" | "success" | "warning" | "error";
 }
-
-import { cn } from "@/lib/utils";
-import { AlertCircle, AlertTriangle, CheckCircle2, Info } from "lucide-react";
 
 const iconMap = {
 	info: {

--- a/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
+++ b/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { Fragment } from "react";
 import {
 	Breadcrumb,
 	BreadcrumbItem,
@@ -7,8 +9,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import Link from "next/link";
-import { Fragment } from "react";
 
 interface Props {
 	list: {
@@ -26,7 +26,7 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 					<Separator orientation="vertical" className="mr-2 h-4" />
 					<Breadcrumb>
 						<BreadcrumbList>
-							{list.map((item, _index) => (
+							{list.map((item, index) => (
 								<Fragment key={item.name}>
 									<BreadcrumbItem className="block">
 										<BreadcrumbLink href={item.href} asChild={!!item.href}>
@@ -37,7 +37,7 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 											)}
 										</BreadcrumbLink>
 									</BreadcrumbItem>
-									{_index + 1 < list.length && (
+									{index + 1 < list.length && (
 										<BreadcrumbSeparator className="block" />
 									)}
 								</Fragment>

--- a/apps/dokploy/components/shared/code-editor.tsx
+++ b/apps/dokploy/components/shared/code-editor.tsx
@@ -1,20 +1,19 @@
-import { cn } from "@/lib/utils";
-import { json } from "@codemirror/lang-json";
-import { yaml } from "@codemirror/lang-yaml";
-import { StreamLanguage } from "@codemirror/language";
-
 import {
+	autocompletion,
 	type Completion,
 	type CompletionContext,
 	type CompletionResult,
-	autocompletion,
 } from "@codemirror/autocomplete";
+import { json } from "@codemirror/lang-json";
+import { yaml } from "@codemirror/lang-yaml";
+import { StreamLanguage } from "@codemirror/language";
 import { properties } from "@codemirror/legacy-modes/mode/properties";
 import { shell } from "@codemirror/legacy-modes/mode/shell";
 import { EditorView } from "@codemirror/view";
 import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
 import CodeMirror, { type ReactCodeMirrorProps } from "@uiw/react-codemirror";
 import { useTheme } from "next-themes";
+import { cn } from "@/lib/utils";
 
 // Docker Compose completion options
 const dockerComposeServices = [
@@ -101,9 +100,7 @@ function dockerComposeComplete(
 	context: CompletionContext,
 ): CompletionResult | null {
 	const word = context.matchBefore(/\w*/);
-	if (!word) return null;
-
-	if (!word.text && !context.explicit) return null;
+	if (!word || (!word.text && !context.explicit)) return null;
 
 	// Check if we're at the root level
 	const line = context.state.doc.lineAt(context.pos);

--- a/apps/dokploy/components/shared/date-tooltip.tsx
+++ b/apps/dokploy/components/shared/date-tooltip.tsx
@@ -1,3 +1,4 @@
+import { format, formatDistanceToNow } from "date-fns";
 import {
 	Tooltip,
 	TooltipContent,
@@ -5,7 +6,6 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { format, formatDistanceToNow } from "date-fns";
 
 interface Props {
 	date: string;

--- a/apps/dokploy/components/shared/drawer-logs.tsx
+++ b/apps/dokploy/components/shared/drawer-logs.tsx
@@ -1,3 +1,5 @@
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import {
 	Sheet,
 	SheetContent,
@@ -5,8 +7,6 @@ import {
 	SheetHeader,
 	SheetTitle,
 } from "@/components/ui/sheet";
-import { Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 import { TerminalLine } from "../dashboard/docker/logs/terminal-line";
 import type { LogLine } from "../dashboard/docker/logs/utils";
 
@@ -43,11 +43,11 @@ export const DrawerLogs = ({ isOpen, onClose, filteredLogs }: Props) => {
 	return (
 		<Sheet
 			open={!!isOpen}
-			onOpenChange={(_open) => {
+			onOpenChange={() => {
 				onClose();
 			}}
 		>
-			<SheetContent className="sm:max-w-[740px]  flex flex-col">
+			<SheetContent className="sm:max-w-[740px] flex flex-col">
 				<SheetHeader>
 					<SheetTitle>Deployment Logs</SheetTitle>
 					<SheetDescription>Details of the request log entry.</SheetDescription>

--- a/apps/dokploy/components/shared/toggle-visibility-input.tsx
+++ b/apps/dokploy/components/shared/toggle-visibility-input.tsx
@@ -13,10 +13,13 @@ export const ToggleVisibilityInput = ({ ...props }: InputProps) => {
 		setIsPasswordVisible((prevVisibility) => !prevVisibility);
 	};
 
-	const inputType = isPasswordVisible ? "text" : "password";
 	return (
 		<div className="flex w-full items-center space-x-2">
-			<Input ref={inputRef} type={inputType} {...props} />
+			<Input
+				ref={inputRef}
+				type={isPasswordVisible ? "text" : "password"}
+				{...props}
+			/>
 			<Button
 				variant={"secondary"}
 				onClick={() => {
@@ -27,10 +30,10 @@ export const ToggleVisibilityInput = ({ ...props }: InputProps) => {
 				<Clipboard className="size-4 text-muted-foreground" />
 			</Button>
 			<Button onClick={togglePasswordVisibility} variant={"secondary"}>
-				{inputType === "password" ? (
-					<EyeIcon className="size-4 text-muted-foreground" />
-				) : (
+				{isPasswordVisible ? (
 					<EyeOffIcon className="size-4 text-muted-foreground" />
+				) : (
+					<EyeIcon className="size-4 text-muted-foreground" />
 				)}
 			</Button>
 		</div>


### PR DESCRIPTION
## Summary by Sourcery

Apply linting and styling refinements across shared component files to improve consistency and readability.

Enhancements:
- Reorder and consolidate imports, and remove unused imports in shared components for a cleaner codebase.
- Simplify conditional logic and inline temporary variables in code-editor and toggle-visibility-input components.
- Standardize naming and usage patterns by renaming iteration variables, unifying window.chatwootSDKReady assignment, and fixing placement enum ordering.
- Adjust spacing and JSX formatting in breadcrumb-sidebar, drawer-logs, date-tooltip, and alert-block components for consistent styling.