### PR TITLE
build: change `next.config.mjs` → `next.config.ts`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y curl unzip zip apache2-utils iproute2 r
 # Copy only the necessary files
 COPY --from=build /prod/dokploy/.next ./.next
 COPY --from=build /prod/dokploy/dist ./dist
-COPY --from=build /prod/dokploy/next.config.mjs ./next.config.mjs
+COPY --from=build /prod/dokploy/next.config.ts ./next.config.ts
 COPY --from=build /prod/dokploy/public ./public
 COPY --from=build /prod/dokploy/package.json ./package.json
 COPY --from=build /prod/dokploy/drizzle ./drizzle

--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y curl unzip apache2-utils && rm -rf /var
 # Copy only the necessary files
 COPY --from=build /prod/dokploy/.next ./.next
 COPY --from=build /prod/dokploy/dist ./dist
-COPY --from=build /prod/dokploy/next.config.mjs ./next.config.mjs
+COPY --from=build /prod/dokploy/next.config.ts ./next.config.ts
 COPY --from=build /prod/dokploy/public ./public
 COPY --from=build /prod/dokploy/package.json ./package.json
 COPY --from=build /prod/dokploy/drizzle ./drizzle

--- a/apps/dokploy/next.config.ts
+++ b/apps/dokploy/next.config.ts
@@ -3,12 +3,10 @@
  * for Docker builds.
  */
 
-/** @type {import("next").NextConfig} */
-const nextConfig = {
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
 	reactStrictMode: true,
-	eslint: {
-		ignoreDuringBuilds: true,
-	},
 	typescript: {
 		ignoreBuildErrors: true,
 	},

--- a/apps/dokploy/tsconfig.json
+++ b/apps/dokploy/tsconfig.json
@@ -39,7 +39,7 @@
 		"**/*.js",
 		".next/types/**/*.ts",
 		"env.js",
-		"next.config.mjs",
+		"next.config.ts",
 		"next-i18next.config.mjs"
 	],
 	"exclude": [


### PR DESCRIPTION
## Summary by Sourcery

Convert the Next.js configuration file from a JavaScript module to a TypeScript module and update related build references.

Enhancements:
- Convert next.config file from .mjs to .ts and add NextConfig type annotation
- Remove eslint.ignoreDuringBuilds setting from Next.js configuration

Build:
- Update Dockerfiles to copy next.config.ts instead of next.config.mjs

Chores:
- Update tsconfig.json to include and exclude next.config.ts instead of .mjs