### PR TITLE
docs(contributing): use Alerts syntax of GitHub markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,8 @@ pnpm run dokploy:dev
 
 Go to http://localhost:3000 to see the development server
 
-Note: this project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.
+> [!NOTE]
+> This project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.
 
 ## Build
 
@@ -117,10 +118,10 @@ In the case you lost your password, you can reset it using the following command
 pnpm run reset-password
 ```
 
-If you want to test the webhooks on development mode using localtunnel, make sure to install `localtunnel`
+If you want to test the webhooks on development mode using localtunnel, make sure to install [`localtunnel`](https://localtunnel.app/)
 
 ```bash
-bunx lt --port 3000
+pnpm dlx localtunnel --port 3000
 ```
 
 If you run into permission issues of docker run the following command


### PR DESCRIPTION
## Summary by Sourcery

Use GitHub alert syntax in contributing guide and update localtunnel instructions

Enhancements:
- Switch localtunnel command to use pnpm dlx instead of bunx

Documentation:
- Replace plain note with GitHub markdown alert for Biome formatter
- Add hyperlink to localtunnel in the installation instructions